### PR TITLE
feat: Add search functionality to POI list

### DIFF
--- a/src/components/SavedFeaturesDrawer/SavedFeaturesDrawer.tsx
+++ b/src/components/SavedFeaturesDrawer/SavedFeaturesDrawer.tsx
@@ -1,6 +1,7 @@
 import {
   Drawer,
   Box,
+  TextField,
   useTheme,
   useMediaQuery,
 } from "@mui/material"
@@ -12,6 +13,7 @@ import { CategoryContextMenu } from "./ContextMenu/CategoryContextMenu"
 import { FeatureContextMenu } from "./ContextMenu/FeatureContextMenu"
 import { FeatureDragContext } from "./FeatureList/FeatureDragContext"
 import { FeatureList } from "./FeatureList/FeatureList"
+import { filterFeatures } from "./filterUtils" // Import the new helper function
 import { useCategoryManagement } from "./hooks/useCategoryManagement"
 import { useContextMenu } from "./hooks/useContextMenu"
 import { useFeatureManagement } from "./hooks/useFeatureManagement"
@@ -28,6 +30,7 @@ const excludedProperties = ["id", "images", "style"] as const
 
 const SavedFeaturesDrawer: React.FC<SavedFeaturesDrawerProps> = ({ drawerOpen, onClose, setCurrentCategory }) => {
   const [selectedTab, setSelectedTab] = useState<string>(DEFAULT_CATEGORY)
+  const [searchQuery, setSearchQuery] = useState<string>("")
 
   const { savedFeatures, setSavedFeatures, removeFeature } = useContext(SavedFeaturesContext)!
   const { selectedFeature, setSelectedFeature } = useFeatureSelection()
@@ -49,11 +52,19 @@ const SavedFeaturesDrawer: React.FC<SavedFeaturesDrawerProps> = ({ drawerOpen, o
     setSelectedFeature(null)
   }, [setSelectedFeature])
 
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value)
+  }
+
   useEffect(() => {
     if (setCurrentCategory) {
       setCurrentCategory(selectedTab)
     }
   }, [selectedTab, setCurrentCategory])
+
+  const currentFeatures = savedFeatures[selectedTab] || []
+  // Use the filterFeatures helper function
+  const filteredFeatures = filterFeatures(currentFeatures, searchQuery)
 
   return (
     <>
@@ -81,9 +92,17 @@ const SavedFeaturesDrawer: React.FC<SavedFeaturesDrawerProps> = ({ drawerOpen, o
                 handleTabContextMenu={handleTabContextMenu}
               />
             </Box>
-            <Box sx={{ flexGrow: 1, overflowY: "auto" }}>
+            <Box sx={{ flexGrow: 1, overflowY: "auto", p: 2 }}>
+              <TextField
+                fullWidth
+                label="Search Features"
+                variant="outlined"
+                value={searchQuery}
+                onChange={handleSearchChange}
+                sx={{ mb: 2 }}
+              />
               <FeatureList
-                features={savedFeatures[selectedTab] || []}
+                features={filteredFeatures}
                 setSavedFeatures={setSavedFeatures}
                 selectedTab={selectedTab}
                 selectedFeature={selectedFeature}

--- a/src/components/SavedFeaturesDrawer/filterUtils.test.ts
+++ b/src/components/SavedFeaturesDrawer/filterUtils.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { filterFeatures, GeoJsonFeature } from './filterUtils';
+
+// Mock GeoJsonFeature objects
+const mockFeatures: GeoJsonFeature[] = [
+  {
+    type: "Feature",
+    properties: { name: "Alpha Park", description: "A beautiful park with many trees" },
+    geometry: { type: "Point", coordinates: [0, 0] },
+    id: "1"
+  },
+  {
+    type: "Feature",
+    properties: { name: "Beta Garden", description: "A lovely garden full of flowers" },
+    geometry: { type: "Polygon", coordinates: [[[0,0]]]},
+    id: "2"
+  },
+  {
+    type: "Feature",
+    properties: { name: "Gamma Point", description: "A scenic spot with alpha views" },
+    geometry: { type: "LineString", coordinates: [[0,0]]},
+    id: "3"
+  },
+  {
+    type: "Feature",
+    properties: { name: "Delta Place" }, // Missing description
+    geometry: { type: "Point", coordinates: [1, 1] },
+    id: "4"
+  },
+  {
+    type: "Feature",
+    properties: { description: "Epsilon Area with unique plants" }, // Missing name
+    geometry: { type: "Point", coordinates: [2, 2] },
+    id: "5"
+  },
+  {
+    type: "Feature",
+    properties: {}, // Missing both name and description
+    geometry: { type: "Point", coordinates: [3, 3] },
+    id: "6"
+  },
+  {
+    type: "Feature",
+    properties: { name: "zeta spot", description: "another lovely spot" }, // lowercase name for case-insensitivity test
+    geometry: { type: "Point", coordinates: [4, 4] },
+    id: "7"
+  }
+];
+
+describe('filterFeatures', () => {
+  it('should return all features if search query is empty', () => {
+    expect(filterFeatures(mockFeatures, '')).toEqual(mockFeatures);
+  });
+
+  it('should filter by name (exact match)', () => {
+    const result = filterFeatures(mockFeatures, 'Alpha Park');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('Alpha Park');
+  });
+
+  it('should filter by name (partial match)', () => {
+    const result = filterFeatures(mockFeatures, 'Park');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('Alpha Park');
+  });
+
+  it('should filter by name (case-insensitive)', () => {
+    const result = filterFeatures(mockFeatures, 'alpha park');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('Alpha Park');
+  });
+
+  it('should filter by description (exact match)', () => {
+    const result = filterFeatures(mockFeatures, 'A lovely garden full of flowers');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.description).toBe('A lovely garden full of flowers');
+  });
+
+  it('should filter by description (partial match)', () => {
+    const result = filterFeatures(mockFeatures, 'lovely');
+    expect(result).toHaveLength(2); // "Beta Garden" and "zeta spot"
+    expect(result.some(f => f.properties.name === 'Beta Garden')).toBe(true);
+    expect(result.some(f => f.properties.name === 'zeta spot')).toBe(true);
+  });
+
+  it('should filter by description (case-insensitive)', () => {
+    const result = filterFeatures(mockFeatures, 'a lovely garden');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('Beta Garden');
+  });
+
+  it('should filter by query matching part of description ("alpha views")', () => {
+    const result = filterFeatures(mockFeatures, 'alpha views');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('Gamma Point');
+  });
+  
+  it('should filter by query matching part of name ("Gam")', () => {
+    const result = filterFeatures(mockFeatures, 'Gam');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('Gamma Point');
+  });
+
+  it('should return an empty array if no features match the search query', () => {
+    const result = filterFeatures(mockFeatures, 'NonExistentPlace');
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle features with missing description property', () => {
+    const result = filterFeatures(mockFeatures, 'Delta Place');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('Delta Place');
+  });
+
+  it('should handle features with missing name property', () => {
+    const result = filterFeatures(mockFeatures, 'Epsilon Area');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.description).toBe('Epsilon Area with unique plants');
+  });
+  
+  it('should include features if name matches, even if description is missing', () => {
+    const result = filterFeatures(mockFeatures, 'Delta');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('4');
+  });
+
+  it('should include features if description matches, even if name is missing', () => {
+    const result = filterFeatures(mockFeatures, 'Epsilon');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('5');
+  });
+
+  it('should not crash and correctly exclude features with no name or description when searching', () => {
+    const result = filterFeatures(mockFeatures, 'MissingBoth');
+    expect(result).toHaveLength(0);
+  });
+  
+  it('should not include features with missing name and description if search query is non-empty', () => {
+    // Feature with id "6" has no name or description
+    let result = filterFeatures(mockFeatures, 'Alpha');
+    expect(result.some(f => f.id === "6")).toBe(false);
+
+    result = filterFeatures(mockFeatures, 'Anything');
+    expect(result.some(f => f.id === "6")).toBe(false);
+  });
+
+  it('should correctly perform case-insensitive search for names like "zeta spot"', () => {
+    const result = filterFeatures(mockFeatures, 'zeta');
+    expect(result).toHaveLength(1);
+    expect(result[0].properties.name).toBe('zeta spot');
+    
+    const resultCaps = filterFeatures(mockFeatures, 'ZETA');
+    expect(resultCaps).toHaveLength(1);
+    expect(resultCaps[0].properties.name).toBe('zeta spot');
+  });
+
+  it('should return features that match either name or description', () => {
+    // "alpha" is in "Alpha Park" name and "Gamma Point" description
+    const result = filterFeatures(mockFeatures, 'alpha');
+    expect(result).toHaveLength(2);
+    expect(result.some(f => f.properties.name === 'Alpha Park')).toBe(true);
+    expect(result.some(f => f.properties.name === 'Gamma Point')).toBe(true);
+  });
+});

--- a/src/components/SavedFeaturesDrawer/filterUtils.ts
+++ b/src/components/SavedFeaturesDrawer/filterUtils.ts
@@ -1,0 +1,33 @@
+// Define a simplified GeoJsonFeature type for our filtering purposes
+export interface GeoJsonFeature {
+  type: "Feature";
+  properties: {
+    // Making name and description optional as per test cases
+    name?: string;
+    description?: string;
+    // Allow other properties
+    [key: string]: any;
+  };
+  geometry: {
+    type: string;
+    coordinates: any;
+  };
+  id?: string;
+}
+
+export const filterFeatures = (features: GeoJsonFeature[], searchQuery: string): GeoJsonFeature[] => {
+  if (!searchQuery) {
+    return features;
+  }
+
+  const query = searchQuery.toLowerCase();
+  return features.filter(feature => {
+    const nameMatch = feature.properties?.name &&
+      typeof feature.properties.name === "string" &&
+      feature.properties.name.toLowerCase().includes(query);
+    const descriptionMatch = feature.properties?.description &&
+      typeof feature.properties.description === "string" &&
+      feature.properties.description.toLowerCase().includes(query);
+    return nameMatch || descriptionMatch;
+  });
+};


### PR DESCRIPTION
Implements a search filter for the Points of Interest (POI) list within the SavedFeaturesDrawer.

Key changes:
- Added a TextField to the SavedFeaturesDrawer for search input.
- Implemented state management for the search query.
- Introduced filtering logic that searches POI names and descriptions (case-insensitive).
- Refactored the filtering logic into a separate utility function `filterFeatures` in `filterUtils.ts` for better code organization and testability.
- Added comprehensive unit tests for the `filterFeatures` function to ensure correctness across various scenarios, including partial matches, case-insensitivity, and handling of missing properties.