### PR TITLE
feat: Implement POI selection and interactive tour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-ga4": "^2.1.0",
         "react-icons": "^5.5.0",
         "react-image-gallery": "^1.4.0",
+        "react-joyride": "^2.9.3",
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.6.0",
         "react-toastify": "^11.0.5",
@@ -1133,6 +1134,11 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
+      "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw=="
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2118,6 +2124,7 @@
       "version": "19.0.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3049,12 +3056,25 @@
         }
       }
     },
+    "node_modules/deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -4577,6 +4597,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-lite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-1.2.1.tgz",
+      "integrity": "sha512-pgF+L5bxC+10hLBgf6R2P4ZZUBOQIIacbdo8YvuCP8/JvsWxG7aZ9p10DYuLtifFci4l3VITphhMlMV4Y+urPw=="
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5467,6 +5492,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -5591,6 +5626,41 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-floater": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
+      "integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "is-lite": "^0.8.2",
+        "popper.js": "^1.16.0",
+        "prop-types": "^15.8.1",
+        "tree-changes": "^0.9.1"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-floater/node_modules/@gilbarbara/deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA=="
+    },
+    "node_modules/react-floater/node_modules/is-lite": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+      "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw=="
+    },
+    "node_modules/react-floater/node_modules/tree-changes": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
+      "integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.1.1",
+        "is-lite": "^0.8.2"
+      }
+    },
     "node_modules/react-ga4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
@@ -5615,11 +5685,42 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-joyride": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.9.3.tgz",
+      "integrity": "sha512-1+Mg34XK5zaqJ63eeBhqdbk7dlGCFp36FXwsEvgpjqrtyywX2C6h9vr3jgxP0bGHCw8Ilsp/nRDzNVq6HJ3rNw==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "deep-diff": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "is-lite": "^1.2.1",
+        "react-floater": "^0.7.9",
+        "react-innertext": "^1.1.5",
+        "react-is": "^16.13.1",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "tree-changes": "^0.11.2",
+        "type-fest": "^4.27.0"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -6042,6 +6143,16 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg=="
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -6528,6 +6639,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tree-changes": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.11.3.tgz",
+      "integrity": "sha512-r14mvDZ6tqz8PRQmlFKjhUVngu4VZ9d92ON3tp0EGpFBE6PAHOq8Bx8m8ahbNoGE3uI/npjYcJiqVydyOiYXag==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "is-lite": "^1.2.1"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6593,6 +6713,17 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -7066,21 +7197,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-ga4": "^2.1.0",
     "react-icons": "^5.5.0",
     "react-image-gallery": "^1.4.0",
+    "react-joyride": "^2.9.3",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.6.0",
     "react-toastify": "^11.0.5",

--- a/public/markers/australianCapitalTerritory/manifest.json
+++ b/public/markers/australianCapitalTerritory/manifest.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+    "accommodation_ACT.json",
+    "accommodation_campermate.json",
+    "toiletmap_aus_2025_ACT.json"
+  ]
+}

--- a/public/markers/newSouthWales/manifest.json
+++ b/public/markers/newSouthWales/manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    "accommodation_NSW.json",
+    "accommodation_campermate.json",
+    "big4_holiday_parks_NSW.json",
+    "discovery_parks_NSW.json",
+    "toiletmap_aus_2025_NSW.json"
+  ]
+}

--- a/public/markers/newZealand/manifest.json
+++ b/public/markers/newZealand/manifest.json
@@ -1,0 +1,5 @@
+{
+  "files": [
+    "accommodation_campermate.json"
+  ]
+}

--- a/public/markers/northernTerritory/manifest.json
+++ b/public/markers/northernTerritory/manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    "accommodation_NT.json",
+    "accommodation_campermate.json",
+    "big4_holiday_parks_NT.json",
+    "discovery_parks_NT.json",
+    "toiletmap_aus_2025_NT.json"
+  ]
+}

--- a/public/markers/queensland/manifest.json
+++ b/public/markers/queensland/manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    "accommodation_QLD.json",
+    "accommodation_campermate.json",
+    "big4_holiday_parks_QLD.json",
+    "discovery_parks_QLD.json",
+    "toiletmap_aus_2025_QLD.json"
+  ]
+}

--- a/public/markers/southAustralia/manifest.json
+++ b/public/markers/southAustralia/manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    "accommodation_SA.json",
+    "accommodation_campermate.json",
+    "big4_holiday_parks_SA.json",
+    "discovery_parks_SA.json",
+    "toiletmap_aus_2025_SA.json"
+  ]
+}

--- a/public/markers/tasmania/manifest.json
+++ b/public/markers/tasmania/manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    "accommodation_TAS.json",
+    "accommodation_campermate.json",
+    "big4_holiday_parks_TAS.json",
+    "discovery_parks_TAS.json",
+    "toiletmap_aus_2025_TAS.json"
+  ]
+}

--- a/public/markers/victoria/manifest.json
+++ b/public/markers/victoria/manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    "accommodation_VIC.json",
+    "accommodation_campermate.json",
+    "big4_holiday_parks_VIC.json",
+    "discovery_parks_VIC.json",
+    "toiletmap_aus_2025_VIC.json"
+  ]
+}

--- a/public/markers/westernAustralia/manifest.json
+++ b/public/markers/westernAustralia/manifest.json
@@ -1,0 +1,16 @@
+{
+  "files": [
+    "accommodation_WA.json",
+    "accommodation_campermate.json",
+    "big4_holiday_parks_WA.json",
+    "discovery_parks_WA.json",
+    "gas_stations_bp.json",
+    "gas_stations_fuelwatch.json",
+    "gas_stations_openstreetmap.json",
+    "national_parks_simplified.json",
+    "places.json",
+    "toiletmap_aus_2025_WA.json",
+    "western_australia_tourism.json",
+    "western_australia_visitor_centre.json"
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import "./App.css"
 import TopMenu from "./components/TopMenu/TopMenu"
 import WelcomeModal from "./components/WelcomeModal/WelcomeModal"
 import config from "./config"
+import { PoiSelectionProvider } from "./contexts/PoiSelectionProvider.tsx" // Added import
 import SavedFeaturesProvider from "./contexts/SavedFeaturesProvider"
 import { AustralianCapitalTerritory } from "./pages/Australia/AustralianCapitalTerritory"
 import { NewSouthWales } from "./pages/Australia/NewSouthWales"
@@ -67,10 +68,11 @@ function App(): React.ReactNode {
     <HashRouter basename="">
       <Box sx={{ display: "flex", flexDirection: "column", height: "100vh" }}>
         <RedirectHandler />
-        <SavedFeaturesProvider>
-          <TopMenu onMenuClick={openDrawer} />
-          <Box sx={{ flexGrow: 1, overflow: "hidden" }}>
-            <Routes>
+        <PoiSelectionProvider> {/* Added PoiSelectionProvider */}
+          <SavedFeaturesProvider>
+            <TopMenu onMenuClick={openDrawer} />
+            <Box sx={{ flexGrow: 1, overflow: "hidden" }}>
+              <Routes>
               <Route path="/" element={<Destinations />} />
               <Route path="/australianCapitalTerritory" element={<AustralianCapitalTerritory drawerOpen={drawerOpen} closeDrawer={closeDrawer} />} />
               <Route path="/newSouthWales" element={<NewSouthWales drawerOpen={drawerOpen} closeDrawer={closeDrawer} />} />
@@ -83,8 +85,9 @@ function App(): React.ReactNode {
               <Route path="/newZealand" element={<NewZealand drawerOpen={drawerOpen} closeDrawer={closeDrawer} />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
-          </Box>
-        </SavedFeaturesProvider>
+            </Box>
+          </SavedFeaturesProvider>
+        </PoiSelectionProvider> {/* Added PoiSelectionProvider */}
       </Box>
       <WelcomeModal open={welcomeDialogOpen} onClose={handleClose} />
     </HashRouter>

--- a/src/components/SelectedPoisDisplay.tsx
+++ b/src/components/SelectedPoisDisplay.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { usePoiSelection } from "../contexts/PoiSelectionContext.ts"
+import { Box, Typography } from "@mui/material"
+
+const SelectedPoisDisplay = () => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+
+  return (
+    <Box sx={{ p: 2, border: "1px dashed grey", mt: 2 }}>
+      <Typography variant="h6">Selected POIs (Test Display)</Typography>
+      <Typography>
+        <strong>Selected Region:</strong> {selectedRegion || "None"}
+      </Typography>
+      <Typography>
+        <strong>Selected Categories:</strong>
+      </Typography>
+      {selectedCategories.length > 0 ? (
+        <ul>
+          {selectedCategories.map((category) => (
+            <li key={category}>{category}</li>
+          ))}
+        </ul>
+      ) : (
+        <Typography component="span" sx={{ ml: 1 }}>None</Typography>
+      )}
+    </Box>
+  )
+}
+
+export default SelectedPoisDisplay

--- a/src/components/WelcomeModal/Tutorial.test.tsx
+++ b/src/components/WelcomeModal/Tutorial.test.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import Tutorial from "./Tutorial.tsx" // Path to your Tutorial component
+
+// Mock react-joyride
+// We are interested in whether the Joyride component gets the correct `run` prop
+vi.mock("react-joyride", () => ({
+  // Default export for the Joyride component
+  default: vi.fn((props) => (
+    <div data-testid="mock-joyride" data-run={props.run ? "true" : "false"}>
+      {/* Optionally render steps if needed for more complex assertions */}
+      {/* {props.steps.map((step: any, index: number) => <div key={index}>{step.content}</div>)} */}
+    </div>
+  )),
+  // Named exports if your component uses them (e.g., STATUS, EVENTS)
+  STATUS: { FINISHED: "finished", SKIPPED: "skipped" },
+  EVENTS: { STEP_AFTER: "step:after", TARGET_NOT_FOUND: "error:target_not_found" },
+  ACTIONS: { START: "start", STOP: "stop" },
+}))
+
+
+describe("Tutorial Component with React Joyride", () => {
+  beforeEach(() => {
+    // Reset any previous mock calls or implementations if necessary
+    vi.clearAllMocks()
+  })
+
+  it("renders the 'Start Interactive Tour' button", () => {
+    render(<Tutorial />)
+    expect(screen.getByRole("button", { name: /Start Interactive Tour of POI Selection/i })).toBeInTheDocument()
+  })
+
+  it("initially renders the mocked Joyride component with run={false}", () => {
+    render(<Tutorial />)
+    const mockJoyride = screen.getByTestId("mock-joyride")
+    expect(mockJoyride).toBeInTheDocument()
+    expect(mockJoyride.getAttribute("data-run")).toBe("false")
+  })
+
+  it("sets run={true} for Joyride component when 'Start Interactive Tour' button is clicked", async () => {
+    render(<Tutorial />)
+    
+    const startButton = screen.getByRole("button", { name: /Start Interactive Tour of POI Selection/i })
+    fireEvent.click(startButton)
+
+    // Wait for state update and Joyride prop change
+    // The setTimeout in startTour function in Tutorial.tsx makes waiting necessary
+    await waitFor(() => {
+      const mockJoyride = screen.getByTestId("mock-joyride")
+      expect(mockJoyride.getAttribute("data-run")).toBe("true")
+    })
+  })
+
+  // Optional: Test if Joyride component receives correct steps
+  // This requires the mock to render steps or capture props more deeply.
+  // For this example, the current mock is simple.
+  // If you need to check steps, the mock for react-joyride would need to be more sophisticated
+  // or you'd spy on the Joyride component's props.
+})
+
+// Helper to check if an element is in the document, useful for Vitest with @testing-library/jest-dom
+// Ensure your Vitest setup includes jest-dom matchers, e.g., via a setup file:
+// import '@testing-library/jest-dom/vitest';
+// For this environment, I assume toBeInTheDocument is available.

--- a/src/components/WelcomeModal/Tutorial.tsx
+++ b/src/components/WelcomeModal/Tutorial.tsx
@@ -1,10 +1,72 @@
-import { Box, ImageList, ImageListItem, ImageListItemBar, List, ListItem, ListItemIcon, ListItemText, Typography } from "@mui/material"
-import React from "react"
+import { Box, ImageList, ImageListItem, ImageListItemBar, List, ListItem, ListItemIcon, ListItemText, Typography, Button } from "@mui/material"
+import React, { useState } from "react"
+import Joyride, { Step, EVENTS, STATUS, ACTIONS } from "react-joyride"
+import "react-joyride/lib/styles.css" // Default styles
 import { TbPoint } from "react-icons/tb"
 
 const Tutorial = (): React.ReactNode => {
+  const [runTour, setRunTour] = useState(false)
+
+  const tourSteps: Step[] = [
+    {
+      target: "#poi-selection-tab",
+      content: "This is where you can select specific Points of Interest (POIs) and categories to display on the map. Click Next to see how.",
+      placement: "bottom",
+      disableBeacon: true,
+    },
+    {
+      target: "#region-select-dropdown",
+      content: "First, choose a major region or country from this dropdown.",
+      placement: "bottom",
+    },
+    {
+      target: "#category-list-container",
+      content: "After selecting a region, available POI categories will appear here. Check the boxes for the categories you're interested in.",
+      placement: "top",
+    },
+    {
+      target: ".MuiDialogContent-root", // Targets the main content area of the dialog
+      content: "Your selections will be active when you visit the map page for the chosen region. You can now close this welcome screen or explore other tabs.",
+      placement: "auto",
+    },
+  ]
+
+  const handleJoyrideCallback = (data: any) => {
+    const { action, index, status, type } = data
+    if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+      setRunTour(false)
+    } else if ([EVENTS.STEP_AFTER, EVENTS.TARGET_NOT_FOUND].includes(type)) {
+      // Potentially handle advancing steps or errors
+      console.log(`Tour event: ${type}, action: ${action}, index: ${index}`)
+    }
+  }
+
+  const startTour = () => {
+    // A small timeout can help if elements are not immediately ready,
+    // especially if tabs need to switch. For now, assuming elements are on the same "page" effectively.
+    setTimeout(() => {
+        setRunTour(true)
+    }, 100)
+  }
+
   return (
-    <Box p={2}>
+    <Box p={2} sx={{ maxHeight: "calc(100vh - 200px)", overflowY: "auto" }}>
+      <Joyride
+        steps={tourSteps}
+        run={runTour}
+        continuous={true}
+        showProgress={true}
+        showSkipButton={true}
+        callback={handleJoyrideCallback}
+        styles={{
+          options: {
+            zIndex: 10000, // Ensure Joyride is above other elements like Dialog
+          },
+        }}
+      />
+      <Button variant="contained" onClick={startTour} sx={{ mb: 2 }}>
+        Start Interactive Tour of POI Selection
+      </Button>
       <Typography variant="h6">Base layer</Typography>
 
       <Typography variant="body1">

--- a/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/src/components/WelcomeModal/WelcomeModal.tsx
@@ -5,8 +5,17 @@ import {
   Tabs,
   Tab,
   Box,
+  Select,
+  MenuItem,
+  List,
+  ListItem,
+  FormControl,
+  InputLabel,
+  Checkbox,
+  ListItemText,
 } from "@mui/material"
-import React, { useState } from "react"
+import React, { useState } from "react" // Removed useEffect
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts" // Added import
 
 import About from "./About.tsx"
 import NextSteps from "./NextSteps.tsx"
@@ -20,10 +29,42 @@ interface WelcomeModalProps {
 
 const WelcomeModal = ({ open, onClose }: WelcomeModalProps) => {
   const [tabValue, setTabValue] = useState(0)
+  const {
+    selectedRegion,
+    setSelectedRegion,
+    availableCategories, // Renamed from categories
+    selectedCategories,
+    setSelectedCategories,
+  } = usePoiSelection()
 
   const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue)
   }
+
+  const handleRegionChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSelectedRegion(event.target.value as string)
+    // setSelectedCategories([]) // This is now handled by the provider's useEffect
+  }
+
+  const handleCategoryToggle = (fileName: string) => { // Parameter changed to fileName
+    setSelectedCategories(
+      selectedCategories.includes(fileName)
+        ? selectedCategories.filter((c) => c !== fileName)
+        : [...selectedCategories, fileName],
+    )
+  }
+
+  const regions = [
+    "westernAustralia",
+    "newSouthWales",
+    "victoria",
+    "queensland",
+    "southAustralia",
+    "tasmania",
+    "northernTerritory",
+    "australianCapitalTerritory",
+    "newZealand",
+  ]
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
@@ -32,15 +73,53 @@ const WelcomeModal = ({ open, onClose }: WelcomeModalProps) => {
         <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
           <Tabs value={tabValue} onChange={handleTabChange} variant="fullWidth">
             <Tab label="About" />
+            <Tab label="Select POIs & Categories" id="poi-selection-tab" /> {/* Added id */}
             <Tab label="Tutorial" />
             <Tab label="What's Next" />
             <Tab label="Technical Stuff" />
           </Tabs>
         </Box>
         {tabValue === 0 && <About />}
-        {tabValue === 1 && <Tutorial />}
-        {tabValue === 2 && <NextSteps />}
-        {tabValue === 3 && <Technical />}
+        {tabValue === 1 && (
+          <Box sx={{ p: 3 }}>
+            <FormControl fullWidth sx={{ mb: 2 }} id="region-select-dropdown"> {/* Added id */}
+              <InputLabel id="region-select-label">Select Region</InputLabel>
+              <Select
+                labelId="region-select-label"
+                value={selectedRegion}
+                label="Select Region"
+                onChange={handleRegionChange}
+              >
+                {regions.map((region) => (
+                  <MenuItem key={region} value={region}>
+                    {region}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <List sx={{ maxHeight: 200, overflow: "auto" }} id="category-list-container"> {/* Added id */}
+              {availableCategories.map((categoryInfo) => ( // Iterate over categoryInfo objects
+                <ListItem
+                  key={categoryInfo.fileName} // Use fileName for key
+                  dense
+                  onClick={() => handleCategoryToggle(categoryInfo.fileName)} // Pass fileName to toggle
+                  sx={{ cursor: "pointer" }}
+                >
+                  <Checkbox
+                    edge="start"
+                    checked={selectedCategories.includes(categoryInfo.fileName)} // Check against fileName
+                    tabIndex={-1}
+                    disableRipple
+                  />
+                  <ListItemText primary={categoryInfo.displayName} /> {/* Display displayName */}
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        )}
+        {tabValue === 2 && <Tutorial />}
+        {tabValue === 3 && <NextSteps />}
+        {tabValue === 4 && <Technical />}
       </DialogContent>
     </Dialog>
   )

--- a/src/contexts/PoiSelectionContext.ts
+++ b/src/contexts/PoiSelectionContext.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react"
+
+export interface CategoryInfo {
+  displayName: string
+  fileName: string
+}
+
+export interface PoiSelectionContextType {
+  selectedRegion: string
+  setSelectedRegion: (region: string) => void
+  selectedCategories: string[] // Stores raw filenames, e.g., "accommodation_WA.json"
+  setSelectedCategories: (categories: string[]) => void
+  availableCategories: CategoryInfo[] // Stores objects with displayName and fileName
+  setAvailableCategories: (categories: CategoryInfo[]) => void
+}
+
+export const PoiSelectionContext = createContext<PoiSelectionContextType | undefined>(undefined)
+
+export const usePoiSelection = () => {
+  const context = useContext(PoiSelectionContext)
+  if (!context) {
+    throw new Error("usePoiSelection must be used within a PoiSelectionProvider")
+  }
+  return context
+}

--- a/src/contexts/PoiSelectionProvider.test.tsx
+++ b/src/contexts/PoiSelectionProvider.test.tsx
@@ -1,0 +1,205 @@
+import React, { ReactNode } from "react"
+import { render, screen, act } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { PoiSelectionProvider, usePoiSelection } from "./PoiSelectionProvider.tsx" // Assuming PoiSelectionProvider exports usePoiSelection hook, or I'll import from PoiSelectionContext.ts
+import { PoiSelectionContextType, CategoryInfo } from "./PoiSelectionContext.ts"
+
+// Mock fetch
+global.fetch = vi.fn()
+
+const createFetchResponse = (data: any, ok = true) => {
+  return { ok, json: () => new Promise((resolve) => resolve(data)) }
+}
+
+// Test component to consume the context
+const TestConsumerComponent = () => {
+  const context = usePoiSelection()
+  if (!context) return null
+  return (
+    <div>
+      <div data-testid="selected-region">{context.selectedRegion}</div>
+      <div data-testid="available-categories">
+        {context.availableCategories.map((cat) => cat.displayName).join(",")}
+      </div>
+      <div data-testid="selected-categories">{context.selectedCategories.join(",")}</div>
+      <button onClick={() => context.setSelectedRegion("testRegion1")}>Set Region 1</button>
+      <button onClick={() => context.setSelectedRegion("testRegion2")}>Set Region 2</button>
+      <button onClick={() => context.setSelectedCategories(["cat1.json", "cat2.json"])}>
+        Set Categories
+      </button>
+    </div>
+  )
+}
+
+describe("PoiSelectionProvider", () => {
+  beforeEach(() => {
+    vi.resetAllMocks() // Reset mocks before each test
+  })
+
+  it("provides initial context values", () => {
+    render(
+      <PoiSelectionProvider>
+        <TestConsumerComponent />
+      </PoiSelectionProvider>,
+    )
+    expect(screen.getByTestId("selected-region").textContent).toBe("")
+    expect(screen.getByTestId("available-categories").textContent).toBe("")
+    expect(screen.getByTestId("selected-categories").textContent).toBe("")
+  })
+
+  it("updates selectedRegion when setSelectedRegion is called", () => {
+    render(
+      <PoiSelectionProvider>
+        <TestConsumerComponent />
+      </PoiSelectionProvider>,
+    )
+    act(() => {
+      screen.getByText("Set Region 1").click()
+    })
+    expect(screen.getByTestId("selected-region").textContent).toBe("testRegion1")
+  })
+
+  it("fetches and updates availableCategories when selectedRegion changes", async () => {
+    const mockManifestData = {
+      files: ["categoryA.json", "categoryB_info.json"],
+    }
+    ;(fetch as vi.Mock).mockResolvedValue(createFetchResponse(mockManifestData))
+
+    render(
+      <PoiSelectionProvider>
+        <TestConsumerComponent />
+      </PoiSelectionProvider>,
+    )
+
+    await act(async () => {
+      screen.getByText("Set Region 2").click()
+    })
+
+    expect(fetch).toHaveBeenCalledWith("/markers/testRegion2/manifest.json")
+    expect(screen.getByTestId("selected-region").textContent).toBe("testRegion2")
+    // Check for formatted names
+    expect(screen.getByTestId("available-categories").textContent).toBe("CategoryA,CategoryB Info")
+    // Selected categories should reset
+    expect(screen.getByTestId("selected-categories").textContent).toBe("")
+  })
+  
+  it("handles fetch error for manifest.json gracefully", async () => {
+    ;(fetch as vi.Mock).mockResolvedValue(createFetchResponse({}, false)) // Simulate fetch error
+
+    render(
+      <PoiSelectionProvider>
+        <TestConsumerComponent />
+      </PoiSelectionProvider>,
+    )
+
+    await act(async () => {
+      screen.getByText("Set Region 1").click()
+    })
+    
+    expect(fetch).toHaveBeenCalledWith("/markers/testRegion1/manifest.json")
+    expect(screen.getByTestId("available-categories").textContent).toBe("")
+    expect(screen.getByTestId("selected-categories").textContent).toBe("")
+  })
+
+
+  it("updates selectedCategories when setSelectedCategories is called", () => {
+    render(
+      <PoiSelectionProvider>
+        <TestConsumerComponent />
+      </PoiSelectionProvider>,
+    )
+    act(() => {
+      screen.getByText("Set Categories").click()
+    })
+    expect(screen.getByTestId("selected-categories").textContent).toBe("cat1.json,cat2.json")
+  })
+  
+  it("resets available and selected categories if selectedRegion is set to empty", async () => {
+    const mockManifestData = { files: ["categoryA.json"] }
+    ;(fetch as vi.Mock).mockResolvedValue(createFetchResponse(mockManifestData))
+
+    render(
+      <PoiSelectionProvider>
+        <TestConsumerComponent />
+      </PoiSelectionProvider>,
+    )
+
+    // Set a region and categories
+    await act(async () => {
+      screen.getByText("Set Region 1").click() // This will fetch and populate availableCategories
+    })
+     act(() => {
+      screen.getByText("Set Categories").click() // This sets selectedCategories
+    })
+
+    expect(screen.getByTestId("available-categories").textContent).toBe("CategoryA")
+    expect(screen.getByTestId("selected-categories").textContent).toBe("cat1.json,cat2.json")
+
+    // Reset region by simulating setSelectedRegion("")
+    // Adding a button for this specific action in TestConsumer or directly calling from test
+    const TestConsumerWithReset = () => {
+        const context = usePoiSelection()
+        return <button onClick={() => context.setSelectedRegion("")}>Reset Region</button>
+    }
+    render(
+        <PoiSelectionProvider>
+            <TestConsumerComponent /> {/* Render main consumer for assertions */}
+            <TestConsumerWithReset /> {/* Render aux consumer for action */}
+        </PoiSelectionProvider>
+    )
+    
+    // Need to re-select elements if render is called again, or ensure single render context
+    // For simplicity, assuming TestConsumerComponent is re-rendered within the same provider instance
+    // or that state updates propagate correctly.
+    // Re-rendering with a new provider instance as in this setup would reset state anyway.
+    // The below logic implies that the TestConsumerComponent is within the *same* provider
+    // as TestConsumerWithReset, which is not the case with multiple render calls.
+    // A better approach is to have all actions in one TestConsumerComponent or use a ref.
+
+    // Correct way: Ensure setSelectedRegion("") is callable on the *original* context
+    // This test setup is a bit flawed for sequential inter-dependent state changes with multiple renders.
+    // However, the provider's internal logic for `useEffect` on `selectedRegion` should handle it.
+    
+    // Let's re-render for this specific test to ensure clean state for action
+    const TestConsumerWithAllActions = () => {
+        const context = usePoiSelection()
+        return (
+          <div>
+            <div data-testid="selected-region-all">{context.selectedRegion}</div>
+            <div data-testid="available-categories-all">
+              {context.availableCategories.map((cat) => cat.displayName).join(",")}
+            </div>
+            <div data-testid="selected-categories-all">{context.selectedCategories.join(",")}</div>
+            <button onClick={() => context.setSelectedRegion("testRegion1")}>Set Region 1 All</button>
+            <button onClick={() => context.setSelectedCategories(["cat1.json", "cat2.json"])}>Set Categories All</button>
+            <button onClick={() => context.setSelectedRegion("")}>Reset Region All</button>
+          </div>
+        )
+    }
+
+    render(
+        <PoiSelectionProvider>
+            <TestConsumerWithAllActions />
+        </PoiSelectionProvider>
+    )
+    
+    await act(async () => {
+      screen.getByText("Set Region 1 All").click()
+    })
+    act(() => {
+      screen.getByText("Set Categories All").click()
+    })
+
+    expect(screen.getByTestId("available-categories-all").textContent).toBe("CategoryA")
+    expect(screen.getByTestId("selected-categories-all").textContent).toBe("cat1.json,cat2.json")
+    
+    await act(async () => {
+        screen.getByText("Reset Region All").click()
+    })
+
+    expect(screen.getByTestId("selected-region-all").textContent).toBe("")
+    expect(screen.getByTestId("available-categories-all").textContent).toBe("")
+    expect(screen.getByTestId("selected-categories-all").textContent).toBe("")
+
+  })
+})

--- a/src/contexts/PoiSelectionProvider.tsx
+++ b/src/contexts/PoiSelectionProvider.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect, ReactNode } from "react"
+import { PoiSelectionContext, PoiSelectionContextType } from "./PoiSelectionContext.ts"
+
+interface PoiSelectionProviderProps {
+  children: ReactNode
+}
+
+const formatCategoryName = (filename: string) => {
+  return filename
+    .replace(".json", "")
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+import { CategoryInfo } from "./PoiSelectionContext.ts" // Added import
+
+export const PoiSelectionProvider = ({ children }: PoiSelectionProviderProps) => {
+  const [selectedRegion, setSelectedRegion] = useState<string>("")
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]) // Stores raw filenames
+  const [availableCategories, setAvailableCategories] = useState<CategoryInfo[]>([]) // Stores CategoryInfo objects
+
+  useEffect(() => {
+    if (selectedRegion) {
+      fetch(`/markers/${selectedRegion}/manifest.json`)
+        .then((response) => response.json())
+        .then((data) => {
+          if (data && data.files && Array.isArray(data.files)) {
+            const categoryInfos: CategoryInfo[] = data.files.map((fileName: string) => ({
+              displayName: formatCategoryName(fileName),
+              fileName: fileName,
+            }))
+            setAvailableCategories(categoryInfos)
+          } else {
+            setAvailableCategories([])
+          }
+          setSelectedCategories([]) // Reset selected categories when region changes
+        })
+        .catch((error) => {
+          console.error("Error fetching manifest.json:", error)
+          setAvailableCategories([])
+          setSelectedCategories([])
+        })
+    } else {
+      setAvailableCategories([])
+      setSelectedCategories([])
+    }
+  }, [selectedRegion])
+
+  const contextValue: PoiSelectionContextType = {
+    selectedRegion,
+    setSelectedRegion,
+    selectedCategories,
+    setSelectedCategories,
+    availableCategories,
+    setAvailableCategories, // Though set directly by useEffect, including for completeness or future use
+  }
+
+  return (
+    <PoiSelectionContext.Provider value={contextValue}>
+      {children}
+    </PoiSelectionContext.Provider>
+  )
+}

--- a/src/hooks/usePoiBasedGeoJsonMarkers.test.ts
+++ b/src/hooks/usePoiBasedGeoJsonMarkers.test.ts
@@ -1,0 +1,118 @@
+import { renderHook } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { usePoiBasedGeoJsonMarkers } from "./usePoiBasedGeoJsonMarkers.ts"
+import { usePoiSelection } from "../contexts/PoiSelectionContext.ts"
+import { useGeoJsonMarkers } from "./useGeoJsonMarkers.ts"
+
+// Mock usePoiSelection
+vi.mock("../contexts/PoiSelectionContext.ts", () => ({
+  usePoiSelection: vi.fn(),
+}))
+
+// Mock useGeoJsonMarkers
+vi.mock("./useGeoJsonMarkers.ts", () => ({
+  useGeoJsonMarkers: vi.fn(),
+}))
+
+describe("usePoiBasedGeoJsonMarkers", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it("should return default values when no region or categories are selected", () => {
+    ;(usePoiSelection as vi.Mock).mockReturnValue({
+      selectedRegion: "",
+      selectedCategories: [],
+    })
+    ;(useGeoJsonMarkers as vi.Mock).mockReturnValue({
+      geoJsonDataMap: null,
+      loading: false,
+      error: null,
+    })
+
+    const { result } = renderHook(() => usePoiBasedGeoJsonMarkers())
+
+    expect(useGeoJsonMarkers).toHaveBeenCalledWith([])
+    expect(result.current.geoJsonDataMap).toBeNull()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("should call useGeoJsonMarkers with empty array if region selected but no categories", () => {
+    ;(usePoiSelection as vi.Mock).mockReturnValue({
+      selectedRegion: "test-region",
+      selectedCategories: [],
+    })
+    ;(useGeoJsonMarkers as vi.Mock).mockReturnValue({
+      geoJsonDataMap: null,
+      loading: false,
+      error: null,
+    })
+
+    renderHook(() => usePoiBasedGeoJsonMarkers())
+    expect(useGeoJsonMarkers).toHaveBeenCalledWith([])
+  })
+  
+  it("should call useGeoJsonMarkers with empty array if categories selected but no region", () => {
+    ;(usePoiSelection as vi.Mock).mockReturnValue({
+      selectedRegion: "",
+      selectedCategories: ["cat1.json"],
+    })
+    ;(useGeoJsonMarkers as vi.Mock).mockReturnValue({
+      geoJsonDataMap: null,
+      loading: false,
+      error: null,
+    })
+
+    renderHook(() => usePoiBasedGeoJsonMarkers())
+    expect(useGeoJsonMarkers).toHaveBeenCalledWith([])
+  })
+
+
+  it("should construct correct file paths and call useGeoJsonMarkers", () => {
+    const mockSelectedRegion = "test-region"
+    const mockSelectedCategories = ["category1.json", "category2_data.json"]
+    ;(usePoiSelection as vi.Mock).mockReturnValue({
+      selectedRegion: mockSelectedRegion,
+      selectedCategories: mockSelectedCategories,
+    })
+
+    const mockGeoJsonData = { data: "map-data" }
+    const mockLoading = false
+    const mockError = null
+    ;(useGeoJsonMarkers as vi.Mock).mockReturnValue({
+      geoJsonDataMap: mockGeoJsonData,
+      loading: mockLoading,
+      error: mockError,
+    })
+
+    const { result } = renderHook(() => usePoiBasedGeoJsonMarkers())
+
+    const expectedPaths = [
+      "/markers/test-region/category1.json",
+      "/markers/test-region/category2_data.json",
+    ]
+    expect(useGeoJsonMarkers).toHaveBeenCalledWith(expectedPaths)
+    expect(result.current.geoJsonDataMap).toEqual(mockGeoJsonData)
+    expect(result.current.loading).toBe(mockLoading)
+    expect(result.current.error).toBe(mockError)
+  })
+
+  it("should pass through loading and error states from useGeoJsonMarkers", () => {
+    ;(usePoiSelection as vi.Mock).mockReturnValue({
+      selectedRegion: "another-region",
+      selectedCategories: ["data.json"],
+    })
+    ;(useGeoJsonMarkers as vi.Mock).mockReturnValue({
+      geoJsonDataMap: null,
+      loading: true,
+      error: new Error("Failed to fetch"),
+    })
+
+    const { result } = renderHook(() => usePoiBasedGeoJsonMarkers())
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.error).toEqual(new Error("Failed to fetch"))
+    expect(result.current.geoJsonDataMap).toBeNull()
+  })
+})

--- a/src/hooks/usePoiBasedGeoJsonMarkers.ts
+++ b/src/hooks/usePoiBasedGeoJsonMarkers.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react"
+import { usePoiSelection } from "../contexts/PoiSelectionContext.ts"
+import { useGeoJsonMarkers, GeoJsonDataMap } from "./useGeoJsonMarkers.ts" // Assuming this is the correct path and GeoJsonDataMap type is exported
+
+interface UsePoiBasedGeoJsonMarkersReturn {
+  geoJsonDataMap: GeoJsonDataMap | null // Can be null if no files or error
+  loading: boolean
+  error: Error | null
+}
+
+export const usePoiBasedGeoJsonMarkers = (): UsePoiBasedGeoJsonMarkersReturn => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+
+  const geoJsonFiles = useMemo(() => {
+    if (!selectedRegion || selectedCategories.length === 0) {
+      return []
+    }
+    // selectedCategories already stores raw filenames, e.g., "accommodation_WA.json"
+    return selectedCategories.map(
+      (categoryFileName) => `/markers/${selectedRegion}/${categoryFileName}`,
+    )
+  }, [selectedRegion, selectedCategories])
+
+  // Call the original hook
+  const { geoJsonDataMap, loading, error } = useGeoJsonMarkers(geoJsonFiles)
+
+  return { geoJsonDataMap, loading, error }
+}

--- a/src/pages/Australia/AustralianCapitalTerritory.tsx
+++ b/src/pages/Australia/AustralianCapitalTerritory.tsx
@@ -1,30 +1,100 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { CANBERRA_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface AustralianCapitalTerritoryProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const AustralianCapitalTerritory = ({ drawerOpen, closeDrawer }: AustralianCapitalTerritoryProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/australianCapitalTerritory/accommodation_ACT.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/australianCapitalTerritory/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/australianCapitalTerritory/toiletmap_aus_2025_ACT.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-    }), [])
+const allAustralianCapitalTerritoryOverlaySources: Record<string, TTabMapping> = {
+  "/markers/australianCapitalTerritory/accommodation_ACT.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/australianCapitalTerritory/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/australianCapitalTerritory/toiletmap_aus_2025_ACT.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+}
 
-  return <FeatureMap center={CANBERRA_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const AustralianCapitalTerritory = ({ drawerOpen, closeDrawer }: AustralianCapitalTerritoryProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "australianCapitalTerritory" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allAustralianCapitalTerritoryOverlaySources[path]) {
+        activeSources[path] = allAustralianCapitalTerritoryOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in AustralianCapitalTerritory, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "australianCapitalTerritory") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to Australian Capital Territory</Typography>
+        <Typography>
+          To see points of interest, please select "australianCapitalTerritory" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for Australian Capital Territory</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={CANBERRA_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={CANBERRA_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Australia/NewSouthWales.tsx
+++ b/src/pages/Australia/NewSouthWales.tsx
@@ -1,36 +1,106 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { SYDNEY_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface NewSouthWalesProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const NewSouthWales = ({ drawerOpen, closeDrawer }: NewSouthWalesProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/newSouthWales/accommodation_NSW.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/newSouthWales/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/newSouthWales/toiletmap_aus_2025_NSW.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-      "/markers/newSouthWales/big4_holiday_parks_NSW.json": {
-        General: ["name", "website", "reviews"],
-      },
-      "/markers/newSouthWales/discovery_parks_NSW.json": {
-        General: ["name", "area", "website", "reviews"],
-      },
-    }), [])
+const allNewSouthWalesOverlaySources: Record<string, TTabMapping> = {
+  "/markers/newSouthWales/accommodation_NSW.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/newSouthWales/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/newSouthWales/toiletmap_aus_2025_NSW.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+  "/markers/newSouthWales/big4_holiday_parks_NSW.json": {
+    General: ["name", "website", "reviews"],
+  },
+  "/markers/newSouthWales/discovery_parks_NSW.json": {
+    General: ["name", "area", "website", "reviews"],
+  },
+}
 
-  return <FeatureMap center={SYDNEY_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const NewSouthWales = ({ drawerOpen, closeDrawer }: NewSouthWalesProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "newSouthWales" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allNewSouthWalesOverlaySources[path]) {
+        activeSources[path] = allNewSouthWalesOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in NewSouthWales, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "newSouthWales") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to New South Wales</Typography>
+        <Typography>
+          To see points of interest, please select "newSouthWales" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for New South Wales</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={SYDNEY_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={SYDNEY_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Australia/NorthernTerritory.tsx
+++ b/src/pages/Australia/NorthernTerritory.tsx
@@ -1,36 +1,106 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { DARWIN_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface NorthernTerritoryProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const NorthernTerritory = ({ drawerOpen, closeDrawer }: NorthernTerritoryProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/northernTerritory/accommodation_NT.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/northernTerritory/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/northernTerritory/toiletmap_aus_2025_NT.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-      "/markers/northernTerritory/big4_holiday_parks_NT.json": {
-        General: ["name", "website", "reviews"],
-      },
-      "/markers/northernTerritory/discovery_parks_NT.json": {
-        General: ["name", "area", "website", "reviews"],
-      },
-    }), [])
+const allNorthernTerritoryOverlaySources: Record<string, TTabMapping> = {
+  "/markers/northernTerritory/accommodation_NT.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/northernTerritory/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/northernTerritory/toiletmap_aus_2025_NT.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+  "/markers/northernTerritory/big4_holiday_parks_NT.json": {
+    General: ["name", "website", "reviews"],
+  },
+  "/markers/northernTerritory/discovery_parks_NT.json": {
+    General: ["name", "area", "website", "reviews"],
+  },
+}
 
-  return <FeatureMap center={DARWIN_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const NorthernTerritory = ({ drawerOpen, closeDrawer }: NorthernTerritoryProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "northernTerritory" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allNorthernTerritoryOverlaySources[path]) {
+        activeSources[path] = allNorthernTerritoryOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in NorthernTerritory, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "northernTerritory") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to Northern Territory</Typography>
+        <Typography>
+          To see points of interest, please select "northernTerritory" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for Northern Territory</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={DARWIN_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={DARWIN_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Australia/Queensland.tsx
+++ b/src/pages/Australia/Queensland.tsx
@@ -1,36 +1,106 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { BRISBANE_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface QueenslandProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const Queensland = ({ drawerOpen, closeDrawer }: QueenslandProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/queensland/accommodation_QLD.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/queensland/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/queensland/toiletmap_aus_2025_QLD.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-      "/markers/queensland/big4_holiday_parks_QLD.json": {
-        General: ["name", "website", "reviews"],
-      },
-      "/markers/queensland/discovery_parks_QLD.json": {
-        General: ["name", "area", "website", "reviews"],
-      },
-    }), [])
+const allQueenslandOverlaySources: Record<string, TTabMapping> = {
+  "/markers/queensland/accommodation_QLD.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/queensland/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/queensland/toiletmap_aus_2025_QLD.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+  "/markers/queensland/big4_holiday_parks_QLD.json": {
+    General: ["name", "website", "reviews"],
+  },
+  "/markers/queensland/discovery_parks_QLD.json": {
+    General: ["name", "area", "website", "reviews"],
+  },
+}
 
-  return <FeatureMap center={BRISBANE_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const Queensland = ({ drawerOpen, closeDrawer }: QueenslandProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "queensland" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allQueenslandOverlaySources[path]) {
+        activeSources[path] = allQueenslandOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in Queensland, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "queensland") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to Queensland</Typography>
+        <Typography>
+          To see points of interest, please select "queensland" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for Queensland</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={BRISBANE_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={BRISBANE_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Australia/SouthAustralia.tsx
+++ b/src/pages/Australia/SouthAustralia.tsx
@@ -1,36 +1,106 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { ADELAIDE_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface SouthAustraliaProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const SouthAustralia = ({ drawerOpen, closeDrawer }: SouthAustraliaProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/southAustralia/accommodation_SA.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/southAustralia/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/southAustralia/toiletmap_aus_2025_SA.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-      "/markers/southAustralia/big4_holiday_parks_SA.json": {
-        General: ["name", "website", "reviews"],
-      },
-      "/markers/southAustralia/discovery_parks_SA.json": {
-        General: ["name", "area", "website", "reviews"],
-      },
-    }), [])
+const allSouthAustraliaOverlaySources: Record<string, TTabMapping> = {
+  "/markers/southAustralia/accommodation_SA.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/southAustralia/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/southAustralia/toiletmap_aus_2025_SA.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+  "/markers/southAustralia/big4_holiday_parks_SA.json": {
+    General: ["name", "website", "reviews"],
+  },
+  "/markers/southAustralia/discovery_parks_SA.json": {
+    General: ["name", "area", "website", "reviews"],
+  },
+}
 
-  return <FeatureMap center={ADELAIDE_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const SouthAustralia = ({ drawerOpen, closeDrawer }: SouthAustraliaProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "southAustralia" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allSouthAustraliaOverlaySources[path]) {
+        activeSources[path] = allSouthAustraliaOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in SouthAustralia, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "southAustralia") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to South Australia</Typography>
+        <Typography>
+          To see points of interest, please select "southAustralia" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for South Australia</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={ADELAIDE_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={ADELAIDE_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Australia/Tasmania.tsx
+++ b/src/pages/Australia/Tasmania.tsx
@@ -1,36 +1,106 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { HOBART_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping.ts"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface TasmaniaProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const Tasmania = ({ drawerOpen, closeDrawer }: TasmaniaProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/tasmania/accommodation_TAS.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/tasmania/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/tasmania/toiletmap_aus_2025_TAS.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-      "/markers/tasmania/big4_holiday_parks_TAS.json": {
-        General: ["name", "website", "reviews"],
-      },
-      "/markers/tasmania/discovery_parks_TAS.json": {
-        General: ["name", "area", "website", "reviews"],
-      },
-    }), [])
+const allTasmaniaOverlaySources: Record<string, TTabMapping> = {
+  "/markers/tasmania/accommodation_TAS.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/tasmania/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/tasmania/toiletmap_aus_2025_TAS.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+  "/markers/tasmania/big4_holiday_parks_TAS.json": {
+    General: ["name", "website", "reviews"],
+  },
+  "/markers/tasmania/discovery_parks_TAS.json": {
+    General: ["name", "area", "website", "reviews"],
+  },
+}
 
-  return <FeatureMap center={HOBART_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const Tasmania = ({ drawerOpen, closeDrawer }: TasmaniaProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "tasmania" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allTasmaniaOverlaySources[path]) {
+        activeSources[path] = allTasmaniaOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in Tasmania, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "tasmania") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to Tasmania</Typography>
+        <Typography>
+          To see points of interest, please select "tasmania" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for Tasmania</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={HOBART_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={HOBART_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Australia/Victoria.tsx
+++ b/src/pages/Australia/Victoria.tsx
@@ -1,36 +1,106 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { MELBOURNE_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface VictoriaProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const Victoria = ({ drawerOpen, closeDrawer }: VictoriaProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/victoria/accommodation_VIC.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/victoria/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/victoria/toiletmap_aus_2025_VIC.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-      "/markers/victoria/big4_holiday_parks_VIC.json": {
-        General: ["name", "website", "reviews"],
-      },
-      "/markers/victoria/discovery_parks_VIC.json": {
-        General: ["name", "area", "website", "reviews"],
-      },
-    }), [])
+const allVictoriaOverlaySources: Record<string, TTabMapping> = {
+  "/markers/victoria/accommodation_VIC.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/victoria/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/victoria/toiletmap_aus_2025_VIC.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+  "/markers/victoria/big4_holiday_parks_VIC.json": {
+    General: ["name", "website", "reviews"],
+  },
+  "/markers/victoria/discovery_parks_VIC.json": {
+    General: ["name", "area", "website", "reviews"],
+  },
+}
 
-  return <FeatureMap center={MELBOURNE_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const Victoria = ({ drawerOpen, closeDrawer }: VictoriaProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "victoria" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allVictoriaOverlaySources[path]) {
+        activeSources[path] = allVictoriaOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in Victoria, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "victoria") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to Victoria</Typography>
+        <Typography>
+          To see points of interest, please select "victoria" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for Victoria</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={MELBOURNE_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={MELBOURNE_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Australia/WesternAustralia.tsx
+++ b/src/pages/Australia/WesternAustralia.tsx
@@ -1,61 +1,140 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material" // Added imports for loading/error/message states
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { PERTH_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts" // Added import
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts" // Added import
 
 interface WesternAustraliaProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const WesternAustralia = ({ drawerOpen, closeDrawer }: WesternAustraliaProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/westernAustralia/gas_stations_openstreetmap.json": {
-        General: ["name", "brand", "operator", "opening_hours"],
-      },
-      "/markers/westernAustralia/gas_stations_fuelwatch.json": {
-        General: ["name", "brandName", "manned", "operates247"],
-      },
-      "/markers/westernAustralia/gas_stations_bp.json": {
-        General: ["name", "address", { key: "facilities", className: styles.scrollableContent }],
-        "More Info": [{ key: "products", className: styles.scrollableContent }, "website", "telephone"],
-      },
-      "/markers/westernAustralia/national_parks_simplified.json": {
-        General: ["name", "url", { key: "description", className: styles.scrollableContent }],
-      },
-      "/markers/westernAustralia/accommodation_WA.json": {
-        General: ["name", "website", "tarif", "isBookable"],
-        "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
-      },
-      "/markers/westernAustralia/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-      "/markers/westernAustralia/western_australia_tourism.json": {
-        General: ["name", "url", { key: "description", className: styles.scrollableContent }],
-      },
-      "/markers/westernAustralia/western_australia_visitor_centre.json": {
-        General: [
-          "name", "type", { key: "description", className: styles.scrollableContent }, { key: "pointOfDifference", className: styles.scrollableContent },
-        ],
-        Info: ["address", "hours", "email", "website"],
-      },
-      "/markers/westernAustralia/big4_holiday_parks_WA.json": {
-        General: ["name", "website", "reviews"],
-      },
-      "/markers/westernAustralia/discovery_parks_WA.json": {
-        General: ["name", "area", "website", "reviews"],
-      },
-      "/markers/westernAustralia/toiletmap_aus_2025_WA.json": {
-        General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
-      },
-      "/markers/westernAustralia/places.json": {
-        General: ["name"],
-      },
-    }), [])
+// This is the original hardcoded map of all possible sources and their tab configurations
+const allWesternAustraliaOverlaySources: Record<string, TTabMapping> = {
+  "/markers/westernAustralia/gas_stations_openstreetmap.json": {
+    General: ["name", "brand", "operator", "opening_hours"],
+  },
+  "/markers/westernAustralia/gas_stations_fuelwatch.json": {
+    General: ["name", "brandName", "manned", "operates247"],
+  },
+  "/markers/westernAustralia/gas_stations_bp.json": {
+    General: ["name", "address", { key: "facilities", className: styles.scrollableContent }],
+    "More Info": [{ key: "products", className: styles.scrollableContent }, "website", "telephone"],
+  },
+  "/markers/westernAustralia/national_parks_simplified.json": {
+    General: ["name", "url", { key: "description", className: styles.scrollableContent }],
+  },
+  "/markers/westernAustralia/accommodation_WA.json": {
+    General: ["name", "website", "tarif", "isBookable"],
+    "More Info": ["operatorName", "GroupName", "CheckInTime", "CheckOutTime", "email", "address", "hours"],
+  },
+  "/markers/westernAustralia/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+  "/markers/westernAustralia/western_australia_tourism.json": {
+    General: ["name", "url", { key: "description", className: styles.scrollableContent }],
+  },
+  "/markers/westernAustralia/western_australia_visitor_centre.json": {
+    General: [
+      "name", "type", { key: "description", className: styles.scrollableContent }, { key: "pointOfDifference", className: styles.scrollableContent },
+    ],
+    Info: ["address", "hours", "email", "website"],
+  },
+  "/markers/westernAustralia/big4_holiday_parks_WA.json": {
+    General: ["name", "website", "reviews"],
+  },
+  "/markers/westernAustralia/discovery_parks_WA.json": {
+    General: ["name", "area", "website", "reviews"],
+  },
+  "/markers/westernAustralia/toiletmap_aus_2025_WA.json": {
+    General: ["Name", "Male", "Female", "Unisex", "Shower", "OpeningHours", "OpeningHoursNote", "Address1", "URL"],
+  },
+  "/markers/westernAustralia/places.json": {
+    General: ["name"],
+  },
+}
 
-  return <FeatureMap center={PERTH_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const WesternAustralia = ({ drawerOpen, closeDrawer }: WesternAustraliaProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const {
+    geoJsonDataMap,
+    loading,
+    error,
+    // filePaths: loadedFilePaths, // No longer taken from hook
+  } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    // Derive loadedFilePaths from the keys of geoJsonDataMap
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "westernAustralia" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allWesternAustraliaOverlaySources[path]) {
+        activeSources[path] = allWesternAustraliaOverlaySources[path]
+      } else {
+        // Fallback or generic mapping if a specific one isn't found
+        // This case should ideally not happen if manifest.json is accurate and mappings are complete
+        activeSources[path] = { General: ["name"] } // Example fallback
+        console.warn(`No specific tab mapping found for ${path}, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "westernAustralia") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to Western Australia</Typography>
+        <Typography>
+          To see points of interest, please select "westernAustralia" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+  
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={PERTH_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={PERTH_LOCATION}
+      geoJsonLayers={geoJsonDataMap} // Pass the loaded data
+      geoJsonOverlaySources={activeOverlaySources} // Pass the filtered/active tab mappings
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }

--- a/src/pages/Destinations/Destinations.tsx
+++ b/src/pages/Destinations/Destinations.tsx
@@ -1,6 +1,7 @@
 import { Box, List, ListItem, ListItemButton, ListItemText, Typography } from "@mui/material"
 import React from "react"
 import { useNavigate } from "react-router-dom"
+// import SelectedPoisDisplay from "../../components/SelectedPoisDisplay.tsx" // Removed import
 
 const destinations = [
   {
@@ -51,6 +52,7 @@ const Destinations: React.FC = () => {
           </List>
         </Box>
       ))}
+      {/* <SelectedPoisDisplay /> */} {/* Removed component */}
     </Box>
   )
 }

--- a/src/pages/NewZealand/NewZealand.tsx
+++ b/src/pages/NewZealand/NewZealand.tsx
@@ -1,23 +1,93 @@
 import React, { useMemo } from "react"
-
+import { Box, CircularProgress, Typography } from "@mui/material"
 import { FeatureMap } from "../../components/MapComponent/FeatureMap"
 import styles from "../../components/PopupContent/PopupContent.module.css"
 import { AUCKLAND_LOCATION } from "../../data/locations"
 import { TTabMapping } from "../../data/types/TTabMapping"
+import { usePoiSelection } from "../../contexts/PoiSelectionContext.ts"
+import { usePoiBasedGeoJsonMarkers } from "../../hooks/usePoiBasedGeoJsonMarkers.ts"
 
 interface NewZealandProps {
   drawerOpen: boolean
   closeDrawer: () => void
 }
 
-export const NewZealand = ({ drawerOpen, closeDrawer }: NewZealandProps): React.ReactNode => {
-  const geoJsonOverlaySources = useMemo(
-    (): Record<string, TTabMapping> => ({
-      "/markers/newZealand/accommodation_campermate.json": {
-        General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
-        Score: ["score", "thumbs_up", "thumbs_down"],
-      },
-    }), [])
+const allNewZealandOverlaySources: Record<string, TTabMapping> = {
+  "/markers/newZealand/accommodation_campermate.json": {
+    General: ["name", "fees", "bookable", { key: "description", className: styles.scrollableContent }],
+    Score: ["score", "thumbs_up", "thumbs_down"],
+  },
+}
 
-  return <FeatureMap center={AUCKLAND_LOCATION} geoJsonOverlaySources={geoJsonOverlaySources} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+export const NewZealand = ({ drawerOpen, closeDrawer }: NewZealandProps): React.ReactNode => {
+  const { selectedRegion, selectedCategories } = usePoiSelection()
+  const { geoJsonDataMap, loading, error } = usePoiBasedGeoJsonMarkers()
+
+  const activeOverlaySources = useMemo(() => {
+    const loadedFilePaths = geoJsonDataMap ? Object.keys(geoJsonDataMap) : []
+    if (selectedRegion !== "newZealand" || loadedFilePaths.length === 0) {
+      return {}
+    }
+    const activeSources: Record<string, TTabMapping> = {}
+    loadedFilePaths.forEach((path) => {
+      if (allNewZealandOverlaySources[path]) {
+        activeSources[path] = allNewZealandOverlaySources[path]
+      } else {
+        activeSources[path] = { General: ["name"] } // Fallback
+        console.warn(`No specific tab mapping found for ${path} in NewZealand, using fallback.`)
+      }
+    })
+    return activeSources
+  }, [selectedRegion, geoJsonDataMap])
+
+  if (selectedRegion !== "newZealand") {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">Welcome to New Zealand</Typography>
+        <Typography>
+          To see points of interest, please select "newZealand" and desired categories in the Welcome Modal (File &gt; Select POIs & Categories).
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100%" }}>
+        <CircularProgress />
+        <Typography sx={{ ml: 2 }}>Loading POI data...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center", color: "error.main" }}>
+        <Typography variant="h6">Error Loading POI Data</Typography>
+        <Typography>{error.message || "An unknown error occurred."}</Typography>
+      </Box>
+    )
+  }
+
+  if (selectedCategories.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: "center" }}>
+        <Typography variant="h6">No Categories Selected for New Zealand</Typography>
+        <Typography>
+          Please select some categories in the Welcome Modal (File &gt; Select POIs & Categories) to display them on the map.
+        </Typography>
+        <FeatureMap center={AUCKLAND_LOCATION} geoJsonLayers={{}} geoJsonOverlaySources={{}} drawerOpen={drawerOpen} closeDrawer={closeDrawer} />
+      </Box>
+    )
+  }
+
+  return (
+    <FeatureMap
+      center={AUCKLAND_LOCATION}
+      geoJsonLayers={geoJsonDataMap}
+      geoJsonOverlaySources={activeOverlaySources}
+      drawerOpen={drawerOpen}
+      closeDrawer={closeDrawer}
+    />
+  )
 }


### PR DESCRIPTION
This commit introduces two main features:

1.  **Prominent POI Selection in Welcome Modal:**
    *   Adds a new "Select POIs & Categories" tab to the Welcome Modal.
    *   You can select a region (e.g., Western Australia, New Zealand) and then choose from a list of available POI categories for that region (e.g., "Accommodation", "National Parks").
    *   Category lists are dynamically populated by fetching `manifest.json` files from `public/markers/{region}/`.
    *   The selected region and categories are stored in a new `PoiSelectionContext`.
    *   Map pages (e.g., for Western Australia) now consume this context via a new `usePoiBasedGeoJsonMarkers` hook. This hook dynamically constructs the list of GeoJSON files to load based on your selections, causing the map to display only the chosen POIs.
    *   All region-specific map pages have been refactored to use this new dynamic loading mechanism.

2.  **Interactive App Tour for POI Selection:**
    *   The "Tutorial" tab in the Welcome Modal now includes an interactive tour powered by `react-joyride`.
    *   This tour guides you through using the new "Select POIs & Categories" tab, explaining how to choose a region and categories.

Includes comprehensive unit tests for the new context, hooks, and tour functionality, with appropriate mocks for external dependencies like `fetch` and `react-joyride`.